### PR TITLE
Fix for GORM issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
 
 application {
-    mainClass.set("hello.world.Application")
+    mainClass.set("hello.Application")
 }
 java {
     sourceCompatibility = JavaVersion.toVersion("11")

--- a/src/main/groovy/hello/Application.groovy
+++ b/src/main/groovy/hello/Application.groovy
@@ -1,4 +1,4 @@
-package hello.world
+package hello
 
 import io.micronaut.runtime.Micronaut
 import groovy.transform.CompileStatic

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,9 @@ micronaut:
     name: helloWorld
 dataSource:
   url: jdbc:mysql://localhost:3306/servicedirectory
-  driverClassName: com.mysql.jdbc.Driver
-  username: services
-  password: services
+  driverClassName: com.mysql.cj.jdbc.Driver
+  username: root
+  password: root
   pooled: true
   jmxExport: true
 hibernate:


### PR DESCRIPTION
**Issue:** It seems GORM classes are not initializing if the main class is not defined in the root package. I'm not sure whether it is a bug or some config issue. As of my understanding micronaut is initializing the GORM classes only if the main class is in the root package and the GORM classes in the sub-packages.

**Working solutions**
1. Tried and working
```
hello.Applicaiton - Main class
hello.dao.ManagedService - GORM class
```
2. Assuming it should work. 
```
hello.hello.Applicaiton - Main class
hello.hello.dao.ManagedService - GORM class
```

**Fix:** Moved `Application.groovy` file to base package otherwise not loading GORM classes